### PR TITLE
Price is not a relation and cannot select_related

### DIFF
--- a/registrasion/admin.py
+++ b/registrasion/admin.py
@@ -82,6 +82,7 @@ class IncludedProductDiscountAdmin(admin.ModelAdmin, EffectsDisplayMixin):
         DiscountForCategoryInline,
     ]
 
+
 @admin.register(conditions.SpeakerDiscount)
 class SpeakerDiscountAdmin(admin.ModelAdmin, EffectsDisplayMixin):
 

--- a/registrasion/controllers/cart.py
+++ b/registrasion/controllers/cart.py
@@ -165,7 +165,6 @@ class CartController(object):
 
         product_quantities = list(product_quantities)
 
-
         # n.b need to add have the existing items first so that the new
         # items override the old ones.
         all_product_quantities = dict(itertools.chain(

--- a/registrasion/controllers/cart.py
+++ b/registrasion/controllers/cart.py
@@ -318,7 +318,7 @@ class CartController(object):
                 errors.append(ve)
 
         if errors:
-            raise(ValidationError(ve))
+            raise(ValidationError(errors))
 
     def _test_required_categories(self):
         ''' Makes sure that the owner of this cart has satisfied all of the

--- a/registrasion/controllers/cart.py
+++ b/registrasion/controllers/cart.py
@@ -445,7 +445,7 @@ class CartController(object):
         # Order the products such that the most expensive ones are
         # processed first.
         product_items = self.cart.productitem_set.all().select_related(
-            "product", "product__category", "product__price"
+            "product", "product__category"
         ).order_by("-product__price")
 
         products = [i.product for i in product_items]

--- a/registrasion/controllers/category.py
+++ b/registrasion/controllers/category.py
@@ -26,7 +26,7 @@ class CategoryController(object):
         products, otherwise it'll do all. '''
 
         # STOPGAP -- this needs to be elsewhere tbqh
-        from product import ProductController
+        from registrasion.controllers.product import ProductController
 
         if products is AllProducts:
             products = inventory.Product.objects.all().select_related(

--- a/registrasion/controllers/credit_note.py
+++ b/registrasion/controllers/credit_note.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from registrasion.models import commerce
 
-from for_id import ForId
+from registrasion.controllers.for_id import ForId
 
 
 class CreditNoteController(ForId, object):

--- a/registrasion/controllers/credit_note.py
+++ b/registrasion/controllers/credit_note.py
@@ -40,7 +40,8 @@ class CreditNoteController(ForId, object):
         paid.
         '''
 
-        from invoice import InvoiceController  # Circular imports bleh.
+        # Circular Import
+        from registrasion.controllers.invoice import InvoiceController
         inv = InvoiceController(invoice)
         inv.validate_allowed_to_pay()
 
@@ -64,7 +65,8 @@ class CreditNoteController(ForId, object):
         a cancellation fee. Must be 0 <= percentage <= 100.
         '''
 
-        from invoice import InvoiceController  # Circular imports bleh.
+        # Circular Import
+        from registrasion.controllers.invoice import InvoiceController
 
         assert(percentage >= 0 and percentage <= 100)
 

--- a/registrasion/controllers/invoice.py
+++ b/registrasion/controllers/invoice.py
@@ -11,9 +11,9 @@ from registrasion.models import commerce
 from registrasion.models import conditions
 from registrasion.models import people
 
-from cart import CartController
-from credit_note import CreditNoteController
-from for_id import ForId
+from registrasion.controllers.cart import CartController
+from registrasion.controllers.credit_note import CreditNoteController
+from registrasion.controllers.for_id import ForId
 
 
 class InvoiceController(ForId, object):

--- a/registrasion/controllers/invoice.py
+++ b/registrasion/controllers/invoice.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Sum
 from django.utils import timezone
 
 from registrasion.contrib.mail import send_email

--- a/registrasion/controllers/item.py
+++ b/registrasion/controllers/item.py
@@ -1,6 +1,7 @@
 ''' NEEDS TESTS '''
 
 import operator
+from functools import reduce
 
 from registrasion.models import commerce
 from registrasion.models import inventory

--- a/registrasion/forms.py
+++ b/registrasion/forms.py
@@ -428,7 +428,7 @@ class InvoicesWithProductAndStatusForm(forms.Form):
         product = [int(i) for i in product]
 
         super(InvoicesWithProductAndStatusForm, self).__init__(*a, **k)
-        print status
+        print(status)
 
         qs = commerce.Invoice.objects.filter(
             status=status or commerce.Invoice.STATUS_UNPAID,

--- a/registrasion/forms.py
+++ b/registrasion/forms.py
@@ -3,7 +3,6 @@ from registrasion.models import commerce
 from registrasion.models import inventory
 
 from django import forms
-from django.core.exceptions import ValidationError
 from django.db.models import Q
 
 
@@ -31,10 +30,11 @@ class ApplyCreditNoteForm(forms.Form):
             })
 
 
-        key = lambda inv: (0 - (inv["user_id"] == self.user.id), inv["id"])
+        key = lambda inv: (0 - (inv["user_id"] == self.user.id), inv["id"])  # noqa
         invoices_annotated.sort(key=key)
 
-        template = "Invoice %(id)d - user: %(user_email)s (%(user_id)d) -  $%(value)d"
+        template = ('Invoice %(id)d - user: %(user_email)s (%(user_id)d) '
+                    '-  $%(value)d')
         return [
             (invoice["id"], template % invoice)
             for invoice in invoices_annotated
@@ -56,6 +56,7 @@ class CancellationFeeForm(forms.Form):
         min_value=0,
         max_value=100,
     )
+
 
 class ManualCreditNoteRefundForm(forms.ModelForm):
 
@@ -407,6 +408,7 @@ def staff_products_form_factory(user):
 
     return StaffProductsForm
 
+
 def staff_products_formset_factory(user):
     ''' Creates a formset of StaffProductsForm for the given user. '''
     form_type = staff_products_form_factory(user)
@@ -446,7 +448,7 @@ class InvoicesWithProductAndStatusForm(forms.Form):
         qs = qs.order_by("id")
 
         self.fields['invoice'].queryset = qs
-        #self.fields['invoice'].initial = [i.id for i in qs] # UNDO THIS LATER
+        # self.fields['invoice'].initial = [i.id for i in qs] # UNDO THIS LATER
 
 
 class InvoiceEmailForm(InvoicesWithProductAndStatusForm):

--- a/registrasion/forms.py
+++ b/registrasion/forms.py
@@ -8,6 +8,8 @@ from django.db.models import Q
 
 class ApplyCreditNoteForm(forms.Form):
 
+    required_css_class = 'label-required'
+
     def __init__(self, user, *a, **k):
         ''' User: The user whose invoices should be made available as
         choices. '''
@@ -51,6 +53,8 @@ class ApplyCreditNoteForm(forms.Form):
 
 class CancellationFeeForm(forms.Form):
 
+    required_css_class = 'label-required'
+
     percentage = forms.DecimalField(
         required=True,
         min_value=0,
@@ -60,12 +64,16 @@ class CancellationFeeForm(forms.Form):
 
 class ManualCreditNoteRefundForm(forms.ModelForm):
 
+    required_css_class = 'label-required'
+
     class Meta:
         model = commerce.ManualCreditNoteRefund
         fields = ["reference"]
 
 
 class ManualPaymentForm(forms.ModelForm):
+
+    required_css_class = 'label-required'
 
     class Meta:
         model = commerce.ManualPayment
@@ -150,6 +158,9 @@ class _HasProductsFields(object):
 
 
 class _ProductsForm(_HasProductsFields, forms.Form):
+
+    required_css_class = 'label-required'
+
     pass
 
 
@@ -312,6 +323,8 @@ class _ItemQuantityProductsForm(_ProductsForm):
 
 class _ItemQuantityProductsFormSet(_HasProductsFields, forms.BaseFormSet):
 
+    required_css_class = 'label-required'
+
     @classmethod
     def set_fields(cls, category, products):
         raise ValueError("set_fields must be called on the underlying Form")
@@ -377,6 +390,9 @@ class _ItemQuantityProductsFormSet(_HasProductsFields, forms.BaseFormSet):
 
 
 class VoucherForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     voucher = forms.CharField(
         label="Voucher code",
         help_text="If you have a voucher code, enter it here",
@@ -416,6 +432,9 @@ def staff_products_formset_factory(user):
 
 
 class InvoicesWithProductAndStatusForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     invoice = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple,
         queryset=commerce.Invoice.objects.all(),

--- a/registrasion/models/__init__.py
+++ b/registrasion/models/__init__.py
@@ -1,4 +1,4 @@
-from commerce import *  # NOQA
-from conditions import *  # NOQA
-from inventory import *  # NOQA
-from people import *  # NOQA
+from registrasion.models.commerce import *  # NOQA
+from registrasion.models.conditions import *  # NOQA
+from registrasion.models.inventory import *  # NOQA
+from registrasion.models.people import *  # NOQA

--- a/registrasion/models/commerce.py
+++ b/registrasion/models/commerce.py
@@ -324,7 +324,7 @@ class CreditNote(PaymentBase):
 
         elif hasattr(self, 'creditnoterefund'):
             reference = self.creditnoterefund.reference
-            print reference
+            print(reference)
             return "Refunded with reference: %s" % reference
 
         raise ValueError("This should never happen.")

--- a/registrasion/reporting/forms.py
+++ b/registrasion/reporting/forms.py
@@ -63,7 +63,6 @@ class GroupByForm(forms.Form):
     )
 
 
-
 def model_fields_form_factory(model):
     ''' Creates a form for specifying fields from a model to display. '''
 

--- a/registrasion/reporting/forms.py
+++ b/registrasion/reporting/forms.py
@@ -16,6 +16,9 @@ def mix_form(*a):
 
 
 class DiscountForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     discount = forms.ModelMultipleChoiceField(
         queryset=conditions.DiscountBase.objects.all(),
         required=False,
@@ -23,6 +26,9 @@ class DiscountForm(forms.Form):
 
 
 class ProductAndCategoryForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     product = forms.ModelMultipleChoiceField(
         queryset=inventory.Product.objects.select_related("category"),
         required=False,
@@ -34,6 +40,9 @@ class ProductAndCategoryForm(forms.Form):
 
 
 class UserIdForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     user = forms.IntegerField(
         label="User ID",
         required=False,
@@ -41,6 +50,9 @@ class UserIdForm(forms.Form):
 
 
 class ProposalKindForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     kind = forms.ModelMultipleChoiceField(
         queryset=proposals_models.ProposalKind.objects.all(),
         required=False,
@@ -48,6 +60,9 @@ class ProposalKindForm(forms.Form):
 
 
 class GroupByForm(forms.Form):
+
+    required_css_class = 'label-required'
+
     GROUP_BY_CATEGORY = "category"
     GROUP_BY_PRODUCT = "product"
 

--- a/registrasion/reporting/reports.py
+++ b/registrasion/reporting/reports.py
@@ -299,10 +299,9 @@ class ReportView(object):
         response = HttpResponse(content_type='text/csv')
 
         writer = csv.writer(response)
-        encode = lambda i: i.encode("utf8") if isinstance(i, unicode) else i
-        writer.writerow(list(encode(i) for i in report.headings()))
+        writer.writerow(report.headings())
         for row in report.rows():
-            writer.writerow(list(encode(i) for i in row))
+            writer.writerow(row)
 
         return response
 

--- a/registrasion/reporting/reports.py
+++ b/registrasion/reporting/reports.py
@@ -1,5 +1,4 @@
 import csv
-import registrasion.reporting.forms
 
 from django.contrib.auth.decorators import user_passes_test
 from django.shortcuts import render

--- a/registrasion/reporting/reports.py
+++ b/registrasion/reporting/reports.py
@@ -1,5 +1,5 @@
 import csv
-import forms
+import registrasion.reporting.forms
 
 from django.contrib.auth.decorators import user_passes_test
 from django.shortcuts import render
@@ -178,7 +178,7 @@ class Links(Report):
         return []
 
     def rows(self, content_type):
-        print self._links
+        print(self._links)
         for url, link_text in self._links:
             yield [
                 self._linked_text(content_type, url, link_text)

--- a/registrasion/reporting/views.py
+++ b/registrasion/reporting/views.py
@@ -163,8 +163,8 @@ def sales_payment_summary():
     data.append([
         "Credit notes - (claimed credit notes + unclaimed credit notes)",
         all_credit_notes - claimed_credit_notes -
-            refunded_credit_notes - unclaimed_credit_notes,
-    ])
+        refunded_credit_notes - unclaimed_credit_notes
+        ])
 
     return ListReport("Sales and Payments Summary", headings, data)
 
@@ -291,8 +291,8 @@ def discount_status(request, form):
 
     items = group_by_cart_status(
         items,
-        ["discount",],
-        ["discount", "discount__description",],
+        ["discount"],
+        ["discount", "discount__description"],
     )
 
     headings = [
@@ -362,6 +362,7 @@ def paid_invoices_by_date(request, form):
         data,
     )
 
+
 @report_view("Credit notes")
 def credit_notes(request, form):
     ''' Shows all of the credit notes in the system. '''
@@ -375,7 +376,9 @@ def credit_notes(request, form):
 
     return QuerysetReport(
         "Credit Notes",
-        ["id", "invoice__user__attendee__attendeeprofilebase__invoice_recipient", "status", "value"],  # NOQA
+        ["id",
+         "invoice__user__attendee__attendeeprofilebase__invoice_recipient",
+         "status", "value"],
         notes,
         headings=["id", "Owner", "Status", "Value"],
         link_view=views.credit_note,
@@ -383,7 +386,7 @@ def credit_notes(request, form):
 
 
 @report_view("Invoices")
-def invoices(request,form):
+def invoices(request, form):
     ''' Shows all of the invoices in the system. '''
 
     invoices = commerce.Invoice.objects.all().order_by("status", "id")
@@ -562,6 +565,7 @@ def attendee_list(request):
 
 ProfileForm = forms.model_fields_form_factory(AttendeeProfile)
 
+
 @report_view(
     "Attendees By Product/Category",
     form_type=forms.mix_form(
@@ -580,7 +584,8 @@ def attendee_data(request, form, user_id=None):
 
     output = []
 
-    by_category = form.cleaned_data["group_by"] == forms.GroupByForm.GROUP_BY_CATEGORY
+    by_category = (
+        form.cleaned_data["group_by"] == forms.GroupByForm.GROUP_BY_CATEGORY)
 
     products = form.cleaned_data["product"]
     categories = form.cleaned_data["category"]
@@ -597,7 +602,8 @@ def attendee_data(request, form, user_id=None):
 
     # Add invoice nag link
     links = []
-    invoice_mailout = reverse(views.invoice_mailout, args=[]) + "?" + request.META["QUERY_STRING"]
+    invoice_mailout = reverse(views.invoice_mailout, args=[])
+    invoice_mailout += "?" + request.META["QUERY_STRING"]
     links += [
         (invoice_mailout + "&status=1", "Send invoice reminders",),
         (invoice_mailout + "&status=2", "Send mail for paid invoices",),
@@ -621,7 +627,7 @@ def attendee_data(request, form, user_id=None):
         by_user[profile.attendee.user] = profile
 
     cart = "attendee__user__cart"
-    cart_status = cart + "__status"
+    cart_status = cart + "__status"  # noqa
     product = cart + "__productitem__product"
     product_name = product + "__name"
     category = product + "__category"
@@ -631,12 +637,12 @@ def attendee_data(request, form, user_id=None):
         grouping_fields = (category, category_name)
         order_by = (category, )
         first_column = "Category"
-        group_name = lambda i: "%s" % (i[category_name], )
+        group_name = lambda i: "%s" % (i[category_name], )  # noqa
     else:
         grouping_fields = (product, product_name, category_name)
         order_by = (category, )
         first_column = "Product"
-        group_name = lambda i: "%s - %s" % (i[category_name], i[product_name])
+        group_name = lambda i: "%s - %s" % (i[category_name], i[product_name])  # noqa
 
     # Group the responses per-field.
     for field in fields:
@@ -663,7 +669,7 @@ def attendee_data(request, form, user_id=None):
             def display_field(value):
                 return value
 
-        status_count = lambda status: Case(When(
+        status_count = lambda status: Case(When(  # noqa
                 attendee__user__cart__status=status,
                 then=Value(1),
             ),
@@ -710,7 +716,8 @@ def attendee_data(request, form, user_id=None):
         else:
             return attr
 
-    headings = ["User ID", "Name", "Email", "Product", "Item Status"] + field_names
+    headings = ["User ID", "Name", "Email", "Product", "Item Status"]
+    headings.extend(field_names)
     data = []
     for item in items:
         profile = by_user[item.cart.user]
@@ -726,7 +733,8 @@ def attendee_data(request, form, user_id=None):
         data.append(line)
 
     output.append(AttendeeListReport(
-        "Attendees by item with profile data", headings, data, link_view=attendee
+        "Attendees by item with profile data", headings, data,
+        link_view=attendee
     ))
     return output
 
@@ -763,7 +771,7 @@ def speaker_registrations(request, form):
 
     return QuerysetReport(
         "Speaker Registration Status",
-        ["id", "speaker_profile__name", "email", "paid_carts",],
+        ["id", "speaker_profile__name", "email", "paid_carts"],
         users,
         link_view=attendee,
     )
@@ -776,7 +784,10 @@ def speaker_registrations(request, form):
     forms.ProductAndCategoryForm,
 )
 def manifest(request, form):
-    ''' Produces the registration manifest for people with the given product type.'''
+    '''
+    Produces the registration manifest for people with the given product
+    type.
+    '''
 
     products = form.cleaned_data["product"]
     categories = form.cleaned_data["category"]
@@ -835,9 +846,9 @@ def manifest(request, form):
     headings = ["User ID", "Name", "Paid", "Unpaid", "Refunded"]
 
     def format_items(item_list):
-        strings = [
-            "%d x %s" % (item.quantity, str(item.product)) for item in item_list
-        ]
+        strings = []
+        for item in item_list:
+            strings.append('%d x %s' % (item.quantity, str(item.product)))
         return ", \n".join(strings)
 
     output = []
@@ -853,4 +864,4 @@ def manifest(request, form):
 
     return ListReport("Manifest", headings, output)
 
-    #attendeeprofilebase.attendee_name()
+    # attendeeprofilebase.attendee_name()

--- a/registrasion/reporting/views.py
+++ b/registrasion/reporting/views.py
@@ -1,4 +1,4 @@
-import forms
+from registrasion.reporting import forms
 
 import collections
 import datetime
@@ -24,11 +24,11 @@ from registrasion import views
 
 from symposion.schedule import models as schedule_models
 
-from reports import get_all_reports
-from reports import Links
-from reports import ListReport
-from reports import QuerysetReport
-from reports import report_view
+from registrasion.reporting.reports import get_all_reports
+from registrasion.reporting.reports import Links
+from registrasion.reporting.reports import ListReport
+from registrasion.reporting.reports import QuerysetReport
+from registrasion.reporting.reports import report_view
 
 
 def CURRENCY():
@@ -95,7 +95,7 @@ def items_sold():
         total_quantity=Sum("quantity"),
     )
 
-    print line_items
+    print(line_items)
 
     headings = ["Description", "Quantity", "Price", "Total"]
 
@@ -414,7 +414,7 @@ def attendee(request, form, user_id=None):
     if user_id is None:
         return attendee_list(request)
 
-    print user_id
+    print(user_id)
 
     attendee = people.Attendee.objects.get(user__id=user_id)
     name = attendee.attendeeprofilebase.attendee_name()

--- a/registrasion/templatetags/registrasion_tags.py
+++ b/registrasion/templatetags/registrasion_tags.py
@@ -4,7 +4,7 @@ from registrasion.controllers.item import ItemController
 
 from django import template
 from django.db.models import Sum
-from urllib import urlencode
+from urllib.parse import urlencode
 
 register = template.Library()
 

--- a/registrasion/tests/test_batch.py
+++ b/registrasion/tests/test_batch.py
@@ -1,6 +1,6 @@
 import pytz
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 from registrasion.controllers.batch import BatchController
 

--- a/registrasion/tests/test_cart.py
+++ b/registrasion/tests/test_cart.py
@@ -15,8 +15,8 @@ from registrasion.models import people
 from registrasion.controllers.batch import BatchController
 from registrasion.controllers.product import ProductController
 
-from controller_helpers import TestingCartController
-from patches import MixInPatches
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.patches import MixInPatches
 
 UTC = pytz.timezone('UTC')
 
@@ -67,7 +67,7 @@ class RegistrationCartTestCase(MixInPatches, TestCase):
         cls.RESERVATION = datetime.timedelta(hours=1)
 
         cls.categories = []
-        for i in xrange(2):
+        for i in range(2):
             cat = inventory.Category.objects.create(
                 name="Category " + str(i + 1),
                 description="This is a test category",
@@ -81,7 +81,7 @@ class RegistrationCartTestCase(MixInPatches, TestCase):
         cls.CAT_2 = cls.categories[1]
 
         cls.products = []
-        for i in xrange(4):
+        for i in range(4):
             prod = inventory.Product.objects.create(
                 name="Product " + str(i + 1),
                 description="This is a test product.",
@@ -459,7 +459,6 @@ class BasicCartTests(RegistrationCartTestCase):
         cart.add_to_cart(self.PROD_1, 1)
         cart.cart.refresh_from_db()
         self.assertEqual(cart.cart.reservation_duration, new_res)
-
 
     def test_reservation_duration_removals(self):
         ''' Reservation duration should update with removals

--- a/registrasion/tests/test_cart.py
+++ b/registrasion/tests/test_cart.py
@@ -85,7 +85,7 @@ class RegistrationCartTestCase(MixInPatches, TestCase):
             prod = inventory.Product.objects.create(
                 name="Product " + str(i + 1),
                 description="This is a test product.",
-                category=cls.categories[i / 2],  # 2 products per category
+                category=cls.categories[int(i / 2)],  # 2 products per category
                 price=Decimal("10.00"),
                 reservation_duration=cls.RESERVATION,
                 limit_per_user=10,

--- a/registrasion/tests/test_ceilings.py
+++ b/registrasion/tests/test_ceilings.py
@@ -3,8 +3,8 @@ import pytz
 
 from django.core.exceptions import ValidationError
 
-from controller_helpers import TestingCartController
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 from registrasion.controllers.discount import DiscountController
 from registrasion.controllers.product import ProductController
@@ -47,36 +47,36 @@ class CeilingsTestCases(RegistrationCartTestCase):
     def test_add_to_cart_ceiling_date_range(self):
         self.make_ceiling(
             "date range ceiling",
-            start_time=datetime.datetime(2015, 01, 01, tzinfo=UTC),
-            end_time=datetime.datetime(2015, 02, 01, tzinfo=UTC))
+            start_time=datetime.datetime(2015, 1, 1, tzinfo=UTC),
+            end_time=datetime.datetime(2015, 2, 1, tzinfo=UTC))
 
         current_cart = TestingCartController.for_user(self.USER_1)
 
         # User should not be able to add whilst we're before start_time
-        self.set_time(datetime.datetime(2014, 01, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2014, 1, 1, tzinfo=UTC))
         with self.assertRaises(ValidationError):
             current_cart.add_to_cart(self.PROD_1, 1)
 
         # User should be able to add whilst we're during date range
         # On edge of start
-        self.set_time(datetime.datetime(2015, 01, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 1, 1, tzinfo=UTC))
         current_cart.add_to_cart(self.PROD_1, 1)
         # In middle
-        self.set_time(datetime.datetime(2015, 01, 15, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 1, 15, tzinfo=UTC))
         current_cart.add_to_cart(self.PROD_1, 1)
         # On edge of end
-        self.set_time(datetime.datetime(2015, 02, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 2, 1, tzinfo=UTC))
         current_cart.add_to_cart(self.PROD_1, 1)
 
         # User should not be able to add whilst we're after date range
-        self.set_time(datetime.datetime(2014, 01, 01, minute=01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2014, 1, 1, minute=1, tzinfo=UTC))
         with self.assertRaises(ValidationError):
             current_cart.add_to_cart(self.PROD_1, 1)
 
     def test_add_to_cart_ceiling_limit_reserved_carts(self):
         self.make_ceiling("Limit ceiling", limit=1)
 
-        self.set_time(datetime.datetime(2015, 01, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 1, 1, tzinfo=UTC))
 
         first_cart = TestingCartController.for_user(self.USER_1)
         second_cart = TestingCartController.for_user(self.USER_2)
@@ -113,7 +113,7 @@ class CeilingsTestCases(RegistrationCartTestCase):
         self.__validation_test()
 
     def __validation_test(self):
-        self.set_time(datetime.datetime(2015, 01, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 1, 1, tzinfo=UTC))
 
         first_cart = TestingCartController.for_user(self.USER_1)
         second_cart = TestingCartController.for_user(self.USER_2)
@@ -144,7 +144,7 @@ class CeilingsTestCases(RegistrationCartTestCase):
             "Multi-product limit discount ceiling",
             limit=2,
         )
-        for i in xrange(2):
+        for i in range(2):
             cart = TestingCartController.for_user(self.USER_1)
             cart.add_to_cart(self.PROD_1, 1)
             cart.next_cart()
@@ -162,7 +162,7 @@ class CeilingsTestCases(RegistrationCartTestCase):
         # after second.
         self.make_ceiling("Multi-product limit ceiling", limit=2)
 
-        for i in xrange(2):
+        for i in range(2):
             cart = TestingCartController.for_user(self.USER_1)
             cart.add_to_cart(self.PROD_1, 1)
             cart.next_cart()

--- a/registrasion/tests/test_credit_note.py
+++ b/registrasion/tests/test_credit_note.py
@@ -1,18 +1,15 @@
 import datetime
 import pytz
 
-from decimal import Decimal
 from django.core.exceptions import ValidationError
 
 from registrasion.models import commerce
-from registrasion.models import conditions
-from registrasion.models import inventory
-from controller_helpers import TestingCartController
-from controller_helpers import TestingCreditNoteController
-from controller_helpers import TestingInvoiceController
-from test_helpers import TestHelperMixin
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingInvoiceController
+from registrasion.tests.test_helpers import TestHelperMixin
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
+
 
 UTC = pytz.timezone('UTC')
 
@@ -142,7 +139,7 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
         invoice.refund()
 
         # There should be one credit note generated out of the invoice.
-        cn = self._credit_note_for_invoice(invoice.invoice)
+        cn = self._credit_note_for_invoice(invoice.invoice)  # noqa
 
         self.assertEquals(1, commerce.CreditNote.unclaimed().count())
 
@@ -324,7 +321,7 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
         # will be invalidated. A new invoice should be generated.
         cart.add_to_cart(self.PROD_1, 1)
         invoice = TestingInvoiceController.for_id(invoice.invoice.id)
-        invoice2 = TestingInvoiceController.for_cart(cart.cart)
+        invoice2 = TestingInvoiceController.for_cart(cart.cart)  # noqa
         cn2 = self._credit_note_for_invoice(invoice.invoice)
 
         invoice._refresh()
@@ -387,7 +384,6 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
         notes_value = self._generate_multiple_credit_notes()
         invoice = self._manual_invoice(notes_value - 1)
 
-
         self.assertEqual(notes_value - 1, invoice.invoice.total_payments())
         self.assertTrue(invoice.invoice.is_paid)
 
@@ -403,14 +399,14 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
         ''' Tests that excess credit notes are untouched if they're not needed
         '''
 
-        notes_value = self._generate_multiple_credit_notes()
+        notes_value = self._generate_multiple_credit_notes()  # noqa
         notes_old = commerce.CreditNote.unclaimed().filter(
             invoice__user=self.USER_1
         )
 
         # Create a manual invoice whose value is smaller than any of the
         # credit notes we created
-        invoice = self._manual_invoice(1)
+        invoice = self._manual_invoice(1)  # noqa
         notes_new = commerce.CreditNote.unclaimed().filter(
             invoice__user=self.USER_1
         )
@@ -422,7 +418,7 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
     def test_credit_notes_are_not_applied_if_user_has_multiple_invoices(self):
 
         # Have an invoice pending with no credit notes; no payment will be made
-        invoice1 = self._invoice_containing_prod_1(1)
+        invoice1 = self._invoice_containing_prod_1(1)  # noqa
         # Create some credit notes.
         self._generate_multiple_credit_notes()
 
@@ -435,7 +431,7 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
 
     def test_credit_notes_are_applied_even_if_some_notes_are_claimed(self):
 
-        for i in xrange(10):
+        for i in range(10):
             # Generate credit note
             invoice1 = self._manual_invoice(1)
             invoice1.pay("Pay", invoice1.invoice.value)
@@ -467,5 +463,5 @@ class CreditNoteTestCase(TestHelperMixin, RegistrationCartTestCase):
 
     def test_cancellation_fee_is_applied_when_another_invoice_is_unpaid(self):
 
-        extra_invoice = self._manual_invoice(23)
+        extra_invoice = self._manual_invoice(23)  # noqa
         self.test_cancellation_fee_is_applied()

--- a/registrasion/tests/test_discount.py
+++ b/registrasion/tests/test_discount.py
@@ -5,9 +5,9 @@ from decimal import Decimal
 from registrasion.models import commerce
 from registrasion.models import conditions
 from registrasion.controllers.discount import DiscountController
-from controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingCartController
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 UTC = pytz.timezone('UTC')
 

--- a/registrasion/tests/test_flag.py
+++ b/registrasion/tests/test_flag.py
@@ -5,11 +5,11 @@ from django.core.exceptions import ValidationError
 from registrasion.models import commerce
 from registrasion.models import conditions
 from registrasion.controllers.category import CategoryController
-from controller_helpers import TestingCartController
-from controller_helpers import TestingInvoiceController
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingInvoiceController
 from registrasion.controllers.product import ProductController
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 UTC = pytz.timezone('UTC')
 

--- a/registrasion/tests/test_group_member.py
+++ b/registrasion/tests/test_group_member.py
@@ -1,16 +1,11 @@
 import pytz
 
 from django.contrib.auth.models import Group
-from django.core.exceptions import ValidationError
 
-from registrasion.models import commerce
 from registrasion.models import conditions
-from registrasion.controllers.category import CategoryController
-from controller_helpers import TestingCartController
-from controller_helpers import TestingInvoiceController
 from registrasion.controllers.product import ProductController
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 UTC = pytz.timezone('UTC')
 

--- a/registrasion/tests/test_helpers.py
+++ b/registrasion/tests/test_helpers.py
@@ -2,9 +2,10 @@ import datetime
 
 from registrasion.models import commerce
 
-from controller_helpers import TestingCartController
-from controller_helpers import TestingCreditNoteController
-from controller_helpers import TestingInvoiceController
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingCreditNoteController
+from registrasion.tests.controller_helpers import TestingInvoiceController
+
 
 class TestHelperMixin(object):
 
@@ -18,7 +19,7 @@ class TestHelperMixin(object):
         items = [("Item", value)]
         due = datetime.timedelta(hours=1)
         inv = TestingInvoiceController.manual_invoice(self.USER_1, due, items)
-        
+
         return TestingInvoiceController(inv)
 
     def _credit_note_for_invoice(self, invoice):

--- a/registrasion/tests/test_invoice.py
+++ b/registrasion/tests/test_invoice.py
@@ -7,12 +7,11 @@ from django.core.exceptions import ValidationError
 from registrasion.models import commerce
 from registrasion.models import conditions
 from registrasion.models import inventory
-from controller_helpers import TestingCartController
-from controller_helpers import TestingCreditNoteController
-from controller_helpers import TestingInvoiceController
-from test_helpers import TestHelperMixin
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingInvoiceController
+from registrasion.tests.test_helpers import TestHelperMixin
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 UTC = pytz.timezone('UTC')
 
@@ -67,7 +66,7 @@ class InvoiceTestCase(TestHelperMixin, RegistrationCartTestCase):
 
     def test_create_invoice_fails_if_cart_invalid(self):
         self.make_ceiling("Limit ceiling", limit=1)
-        self.set_time(datetime.datetime(2015, 01, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 1, 1, tzinfo=UTC))
         current_cart = TestingCartController.for_user(self.USER_1)
         current_cart.add_to_cart(self.PROD_1, 1)
 
@@ -166,7 +165,6 @@ class InvoiceTestCase(TestHelperMixin, RegistrationCartTestCase):
         current_cart.add_to_cart(self.PROD_1, 1)
         return TestingInvoiceController.for_cart(current_cart.cart)
 
-
     def test_zero_value_invoice_is_automatically_paid(self):
         invoice_1 = self._make_zero_value_invoice()
         self.assertTrue(invoice_1.invoice.is_paid)
@@ -220,7 +218,7 @@ class InvoiceTestCase(TestHelperMixin, RegistrationCartTestCase):
         # generate an invoice
         self.add_timedelta(self.RESERVATION * 2)
         cart2.add_to_cart(self.PROD_2, 1)
-        inv2 = TestingInvoiceController.for_cart(cart2.cart)
+        TestingInvoiceController.for_cart(cart2.cart)
 
         # Re-get inv1's invoice; it should void itself on loading.
         inv1 = TestingInvoiceController(inv1.invoice)

--- a/registrasion/tests/test_invoice.py
+++ b/registrasion/tests/test_invoice.py
@@ -98,7 +98,11 @@ class InvoiceTestCase(TestHelperMixin, RegistrationCartTestCase):
 
     def test_total_payments_balance_due(self):
         invoice = self._invoice_containing_prod_1(2)
-        for i in xrange(0, invoice.invoice.value):
+        # range only takes int, and the following logic fails if not a round
+        # number.  So fail if we are not a round number so developer may fix
+        # this test or the product.
+        self.assertTrue((invoice.invoice.value % 1).is_zero())
+        for i in range(0, int(invoice.invoice.value)):
             self.assertTrue(
                 i + 1, invoice.invoice.total_payments()
             )

--- a/registrasion/tests/test_refund.py
+++ b/registrasion/tests/test_refund.py
@@ -1,9 +1,9 @@
 import pytz
 
-from controller_helpers import TestingCartController
-from controller_helpers import TestingInvoiceController
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingInvoiceController
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 from registrasion.models import commerce
 

--- a/registrasion/tests/test_speaker.py
+++ b/registrasion/tests/test_speaker.py
@@ -1,12 +1,6 @@
 import pytz
 
-from django.core.exceptions import ValidationError
-
-from registrasion.models import commerce
 from registrasion.models import conditions
-from registrasion.controllers.category import CategoryController
-from controller_helpers import TestingCartController
-from controller_helpers import TestingInvoiceController
 from registrasion.controllers.product import ProductController
 
 from symposion.conference import models as conference_models
@@ -16,7 +10,7 @@ from symposion.schedule import models as schedule_models
 from symposion.speakers import models as speaker_models
 
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 UTC = pytz.timezone('UTC')
 
@@ -41,7 +35,7 @@ class SpeakerTestCase(RegistrationCartTestCase):
             name="TEST_SECTION",
             slug="testsection",
         )
-        proposal_section = proposal_models.ProposalSection.objects.create(
+        proposal_section = proposal_models.ProposalSection.objects.create(  # noqa
             section=section,
             closed=False,
             published=False,

--- a/registrasion/tests/test_speaker.py
+++ b/registrasion/tests/test_speaker.py
@@ -67,7 +67,7 @@ class SpeakerTestCase(RegistrationCartTestCase):
             kind=kind_1,
             title="Proposal 1",
             abstract="Abstract",
-            description="Description",
+            private_abstract="Private Abstract",
             speaker=speaker_1,
         )
         proposal_models.AdditionalSpeaker.objects.create(
@@ -80,7 +80,7 @@ class SpeakerTestCase(RegistrationCartTestCase):
             kind=kind_2,
             title="Proposal 2",
             abstract="Abstract",
-            description="Description",
+            private_abstract="Private Abstract",
             speaker=speaker_1,
         )
         proposal_models.AdditionalSpeaker.objects.create(

--- a/registrasion/tests/test_voucher.py
+++ b/registrasion/tests/test_voucher.py
@@ -8,10 +8,10 @@ from django.db import transaction
 
 from registrasion.models import conditions
 from registrasion.models import inventory
-from controller_helpers import TestingCartController
-from controller_helpers import TestingInvoiceController
+from registrasion.tests.controller_helpers import TestingCartController
+from registrasion.tests.controller_helpers import TestingInvoiceController
 
-from test_cart import RegistrationCartTestCase
+from registrasion.tests.test_cart import RegistrationCartTestCase
 
 UTC = pytz.timezone('UTC')
 
@@ -21,7 +21,7 @@ class VoucherTestCases(RegistrationCartTestCase):
     def test_apply_voucher(self):
         voucher = self.new_voucher()
 
-        self.set_time(datetime.datetime(2015, 01, 01, tzinfo=UTC))
+        self.set_time(datetime.datetime(2015, 1, 1, tzinfo=UTC))
 
         cart_1 = TestingCartController.for_user(self.USER_1)
         cart_1.apply_voucher(voucher.code)

--- a/registrasion/urls.py
+++ b/registrasion/urls.py
@@ -1,4 +1,4 @@
-from reporting import views as rv
+from registrasion.reporting import views as rv
 
 from django.conf.urls import include
 from django.conf.urls import url

--- a/registrasion/util.py
+++ b/registrasion/util.py
@@ -12,7 +12,7 @@ def generate_access_code():
 
     length = 6
     # all upper-case letters + digits 1-9 (no 0 vs O confusion)
-    chars = string.uppercase + string.digits[1:]
+    chars = string.ascii_uppercase + string.digits[1:]
     # 6 chars => 35 ** 6 = 1838265625 (should be enough for anyone)
     return get_random_string(length=length, allowed_chars=chars)
 

--- a/registrasion/views.py
+++ b/registrasion/views.py
@@ -1,6 +1,4 @@
 import datetime
-import sys
-from registrasion import util
 import zipfile
 
 from registrasion import forms
@@ -926,13 +924,14 @@ Email = namedtuple(
     ("subject", "body", "from_email", "recipient_list"),
 )
 
+
 @user_passes_test(_staff_only)
 def invoice_mailout(request):
     ''' Allows staff to send emails to users based on their invoice status. '''
 
     category = request.GET.getlist("category", [])
-    product  = request.GET.getlist("product", [])
-    status  = request.GET.get("status")
+    product = request.GET.getlist("product", [])
+    status = request.GET.get("status")
 
     form = forms.InvoiceEmailForm(
         request.POST or None,
@@ -951,8 +950,8 @@ def invoice_mailout(request):
             subject = form.cleaned_data["subject"]
             body = Template(form.cleaned_data["body"]).render(
                 Context({
-                    "invoice" : invoice,
-                    "user" : invoice.user,
+                    "invoice": invoice,
+                    "user": invoice.user,
                 })
             )
             recipient_list = [invoice.user.email]
@@ -991,8 +990,8 @@ def badges(request):
     render, or returns a .zip file containing their badges. '''
 
     category = request.GET.getlist("category", [])
-    product  = request.GET.getlist("product", [])
-    status  = request.GET.get("status")
+    product = request.GET.getlist("product", [])
+    status = request.GET.get("status")
 
     form = forms.InvoicesWithProductAndStatusForm(
         request.POST or None,

--- a/registrasion/views.py
+++ b/registrasion/views.py
@@ -1,6 +1,6 @@
 import datetime
 import sys
-import util
+from registrasion import util
 import zipfile
 
 from registrasion import forms


### PR DESCRIPTION
This field is ignored in 1.9, however in 1.10+ it is an error.
As this is a no-op in 1.9, removal keeps functionality while
extending compatability going forward.

For full details please see Django Ticket 10414 at:
https://code.djangoproject.com/ticket/10414