### PR TITLE
Voucher form needs to be processed first

### DIFF
--- a/registrasion/views.py
+++ b/registrasion/views.py
@@ -952,6 +952,19 @@ def amend_registration(request, user_id):
     user = User.objects.get(id=int(user_id))
     current_cart = CartController.for_user(user)
 
+    voucher_form = forms.VoucherForm(
+        request.POST or None,
+        prefix="voucher",
+    )
+
+    if request.POST and voucher_form.has_changed() and voucher_form.is_valid():
+        try:
+            current_cart.apply_voucher(voucher_form.cleaned_data["voucher"])
+            return redirect(amend_registration, user_id)
+        except ValidationError as ve:
+            voucher_form.add_error(None, ve)
+
+ 
     items = commerce.ProductItem.objects.filter(
         cart=current_cart.cart,
     ).select_related("product")
@@ -967,11 +980,6 @@ def amend_registration(request, user_id):
     for item, form in zip(items, formset):
         queryset = inventory.Product.objects.filter(id=item.product.id)
         form.fields["product"].queryset = queryset
-
-    voucher_form = forms.VoucherForm(
-        request.POST or None,
-        prefix="voucher",
-    )
 
     if request.POST and formset.is_valid():
 
@@ -994,13 +1002,6 @@ def amend_registration(request, user_id):
                         continue
                     if form.cleaned_data["product"] == product:
                         form.add_error("quantity", message)
-
-    if request.POST and voucher_form.has_changed() and voucher_form.is_valid():
-        try:
-            current_cart.apply_voucher(voucher_form.cleaned_data["voucher"])
-            return redirect(amend_registration, user_id)
-        except ValidationError as ve:
-            voucher_form.add_error(None, ve)
 
     ic = ItemController(user)
     data = {


### PR DESCRIPTION
Because otherwise, the first form (which will not be in a valid start)
throws errors which prevent the voucher form from ever being processed.

I believe this fixes #133 

Our logs match those reported there:

```
  File "/app/symposion_app/vendor/registrasion/registrasion/views.py", line 996, in amend_registration
    current_cart.apply_voucher(voucher_form.cleaned_data["voucher"])
  File "/app/symposion_app/vendor/registrasion/registrasion/controllers/cart.py", line 41, in inner
    return func(self, *a, **k)
  File "/app/symposion_app/vendor/registrasion/registrasion/controllers/cart.py", line 281, in apply_voucher
    voucher = inventory.Voucher.objects.get(code=voucher_code.upper())
  File "/usr/local/lib/python3.6/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
```

the core problem seems to be trying to operate on the top formset even though the bottom button was clicked

It's possible that simply moving lines 955-969 inf the formset.is_valid() on line 976 would sufficiently resolve the problem too; but this solution is one that I've tested and found to work